### PR TITLE
Feature/default content type

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   namespace :api do
-    post '/linters' => 'linters#parse', :as => :parse_content
+    post '/linters' => 'linters#parse', :as => :parse_content, :defaults => { :format => 'json' }
   end
 
 end

--- a/spec/requests/linting_spec.rb
+++ b/spec/requests/linting_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'linting', type: :request do
+
+  context 'type inference' do
+    it 'should default to JSON' do
+      post '/api/linters', params: {content: 'words'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.not_to raise_error
+    end
+
+    it 'should default to JSON if */* header' do
+      post '/api/linters', params: {content: 'words'}, headers: {'HTTP_ACCEPT' => '*/*'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.not_to raise_error
+    end
+
+    it 'should return JSON if JSON header' do
+      post '/api/linters', params: {content: 'words'}, headers: {'HTTP_ACCEPT' => 'application/json'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.not_to raise_error
+    end
+
+    it 'should return HTML if HTML header' do
+      post '/api/linters', params: {content: 'words'}, headers: {'HTTP_ACCEPT' => 'text/html'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.to raise_error
+    end
+
+    it 'should return JSON if ends in .json' do
+      post '/api/linters.json', params: {content: 'words'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.not_to raise_error
+    end
+
+    it 'should return HTML if ends in .html' do
+      post '/api/linters.html', params: {content: 'words'}
+      expect(response).to be_success
+      expect { JSON.load(response.body) }.to raise_error
+    end
+  end
+
+end

--- a/spec/requests/linting_spec.rb
+++ b/spec/requests/linting_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'linting', type: :request do
     end
 
     it 'should return HTML if HTML header' do
+      pending('respecting JSON default and Accept headers')
       post '/api/linters', params: {content: 'words'}, headers: {'HTTP_ACCEPT' => 'text/html'}
       expect(response).to be_success
       expect { JSON.load(response.body) }.to raise_error


### PR DESCRIPTION
Set the default content type to JSON, accepting that this will override the HTTP Accept header
